### PR TITLE
Use prototype based Recorder for performance boost.

### DIFF
--- a/lib/babel-assertion-visitor.js
+++ b/lib/babel-assertion-visitor.js
@@ -6,34 +6,13 @@ var babelgen = require('babel-generator');
 var define = require('define-properties');
 var toBeCaptured = require('./to-be-captured');
 var toBeSkipped = require('./to-be-skipped');
-var helperCode = '(' + (function () {
-      function PowerAssertRecorder() {
-          this.captured = [];
-      }
-
-      PowerAssertRecorder.prototype._capt = function _capt (value, espath) {
-          this.captured.push({value: value, espath: espath});
-          return value;
-      };
-
-      PowerAssertRecorder.prototype._expr = function _expr (value, args) {
-          return {
-              powerAssertContext: {
-                  value: value,
-                  events: this.captured
-              },
-              source: {
-                  content: args.content,
-                  filepath: args.filepath,
-                  line: args.line,
-                  generator: !!args.generator,
-                  async: !!args.async
-              }
-          };
-      };
-
-      return PowerAssertRecorder;
-  }).toString() + ')()';
+var fs = require('fs');
+var helperCode = '(' +
+  fs.readFileSync(require.resolve('./power-assert-recorder.js'), 'utf8')
+    .split('\n')
+    .slice(2)
+    .join('\n')
+  + ')()';
 
 function BabelAssertionVisitor (babel, matcher, options) {
     this.babel = babel;

--- a/lib/babel-assertion-visitor.js
+++ b/lib/babel-assertion-visitor.js
@@ -6,40 +6,34 @@ var babelgen = require('babel-generator');
 var define = require('define-properties');
 var toBeCaptured = require('./to-be-captured');
 var toBeSkipped = require('./to-be-skipped');
-var helperCode = [
-    '(function () {',
-    '    var captured = [];',
-    '    function _capt (value, espath) {',
-    '        captured.push({value: value, espath: espath});',
-    '        return value;',
-    '    }',
-    '    function _expr (value, args) {',
-    '        var source = {',
-    '            content: args.content,',
-    '            filepath: args.filepath,',
-    '            line: args.line',
-    '        };',
-    '        if (args.generator) {',
-    '            source.generator = true;',
-    '        }',
-    '        if (args.async) {',
-    '            source.async = true;',
-    '        }',
-    '        return {',
-    '            powerAssertContext: {',
-    '                value: value,',
-    '                events: captured',
-    '            },',
-    '            source: source',
-    '        };',
-    '    }',
-    '    return {',
-    '        _capt: _capt,',
-    '        _expr: _expr',
-    '    };',
-    '});'
-].join('\n');
+var helperCode = '(' + (function () {
+      function PowerAssertRecorder() {
+          this.captured = [];
+      }
 
+      PowerAssertRecorder.prototype._capt = function _capt (value, espath) {
+          this.captured.push({value: value, espath: espath});
+          return value;
+      };
+
+      PowerAssertRecorder.prototype._expr = function _expr (value, args) {
+          return {
+              powerAssertContext: {
+                  value: value,
+                  events: this.captured
+              },
+              source: {
+                  content: args.content,
+                  filepath: args.filepath,
+                  line: args.line,
+                  generator: !!args.generator,
+                  async: !!args.async
+              }
+          };
+      };
+
+      return PowerAssertRecorder;
+  }).toString() + ')()';
 
 function BabelAssertionVisitor (babel, matcher, options) {
     this.babel = babel;
@@ -211,7 +205,7 @@ BabelAssertionVisitor.prototype.createNewRecorder = function (nodePath) {
     var helperNameNode = this.getRecordHelperNameNode(nodePath);
     var recorderIdent = nodePath.scope.generateUidIdentifier('rec');
     define(recorderIdent, { _generatedByEspower: true });
-    var init = types.callExpression(helperNameNode, []);
+    var init = types.newExpression(helperNameNode, []);
     define(init, { _generatedByEspower: true });
     nodePath.scope.push({ id: recorderIdent, init: init });
     return recorderIdent;

--- a/lib/power-assert-recorder.js
+++ b/lib/power-assert-recorder.js
@@ -1,0 +1,30 @@
+'use strict';
+module.exports = /* intentional newline */
+  function () {
+  function PowerAssertRecorder() {
+    this.captured = [];
+  }
+
+  PowerAssertRecorder.prototype._capt = function _capt (value, espath) {
+    this.captured.push({value: value, espath: espath});
+    return value;
+  };
+
+  PowerAssertRecorder.prototype._expr = function _expr (value, args) {
+    return {
+      powerAssertContext: {
+        value: value,
+        events: this.captured
+      },
+      source: {
+        content: args.content,
+        filepath: args.filepath,
+        line: args.line,
+        generator: !!args.generator,
+        async: !!args.async
+      }
+    };
+  };
+
+  return PowerAssertRecorder;
+}

--- a/lib/power-assert-recorder.js
+++ b/lib/power-assert-recorder.js
@@ -10,19 +10,13 @@ module.exports = /* intentional newline */
     return value;
   };
 
-  PowerAssertRecorder.prototype._expr = function _expr (value, args) {
+  PowerAssertRecorder.prototype._expr = function _expr (value, source) {
     return {
       powerAssertContext: {
         value: value,
         events: this.captured
       },
-      source: {
-        content: args.content,
-        filepath: args.filepath,
-        line: args.line,
-        generator: !!args.generator,
-        async: !!args.async
-      }
+      source: source
     };
   };
 

--- a/test/fixtures/ArrayExpression/expected-presets-es2015.js
+++ b/test/fixtures/ArrayExpression/expected-presets-es2015.js
@@ -2,7 +2,7 @@
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/ArrayExpression/expected-presets-es2015.js
+++ b/test/fixtures/ArrayExpression/expected-presets-es2015.js
@@ -2,11 +2,11 @@
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt([_rec._capt(foo, 'arguments/0/elements/0'), _rec._capt(bar, 'arguments/0/elements/1')], 'arguments/0'), {
   content: 'assert([foo, bar])',

--- a/test/fixtures/ArrayExpression/expected.js
+++ b/test/fixtures/ArrayExpression/expected.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt([_rec._capt(foo, 'arguments/0/elements/0'), _rec._capt(bar, 'arguments/0/elements/1')], 'arguments/0'), {
   content: 'assert([foo, bar])',

--- a/test/fixtures/ArrayExpression/expected.js
+++ b/test/fixtures/ArrayExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/ArrowFunctionExpression/expected-presets-es2015.js
+++ b/test/fixtures/ArrowFunctionExpression/expected-presets-es2015.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder();
 
 assert(function (v) {
   return v + 1;

--- a/test/fixtures/ArrowFunctionExpression/expected-presets-es2015.js
+++ b/test/fixtures/ArrowFunctionExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder();
 
 assert(function (v) {

--- a/test/fixtures/ArrowFunctionExpression/expected.js
+++ b/test/fixtures/ArrowFunctionExpression/expected.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder();
 
 assert(v => v + 1);
 

--- a/test/fixtures/ArrowFunctionExpression/expected.js
+++ b/test/fixtures/ArrowFunctionExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder();
 
 assert(v => v + 1);

--- a/test/fixtures/AssignmentExpression/expected-presets-es2015.js
+++ b/test/fixtures/AssignmentExpression/expected-presets-es2015.js
@@ -2,7 +2,7 @@
 
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/AssignmentExpression/expected-presets-es2015.js
+++ b/test/fixtures/AssignmentExpression/expected-presets-es2015.js
@@ -2,14 +2,14 @@
 
 var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
     _rec6$_capt,
     _rec6$_capt2,
     _rec7$_capt,

--- a/test/fixtures/AssignmentExpression/expected.js
+++ b/test/fixtures/AssignmentExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/AssignmentExpression/expected.js
+++ b/test/fixtures/AssignmentExpression/expected.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(counter += 1, 'arguments/0'), {
   content: 'assert(counter += 1)',

--- a/test/fixtures/AwaitExpression/expected-presets-stage-3.js
+++ b/test/fixtures/AwaitExpression/expected-presets-stage-3.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; };
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { return step("next", value); }, function (err) { return step("throw", err); }); } } return step("next"); }); }; }
 
 var myAsync = function () {
   var ref = _asyncToGenerator(regeneratorRuntime.mark(function _callee(a) {
-    var _rec = _powerAssertRecorder();
+    var _rec = new _powerAssertRecorder();
 
     return regeneratorRuntime.wrap(function _callee$(_context) {
       while (1) {

--- a/test/fixtures/AwaitExpression/expected-presets-stage-3.js
+++ b/test/fixtures/AwaitExpression/expected-presets-stage-3.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }();
 
 function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { return step("next", value); }, function (err) { return step("throw", err); }); } } return step("next"); }); }; }
 

--- a/test/fixtures/BinaryExpression/expected-presets-es2015.js
+++ b/test/fixtures/BinaryExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/BinaryExpression/expected-presets-es2015.js
+++ b/test/fixtures/BinaryExpression/expected-presets-es2015.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(4 !== 4, 'arguments/0'), {
   content: 'assert(4 !== 4)',

--- a/test/fixtures/BinaryExpression/expected.js
+++ b/test/fixtures/BinaryExpression/expected.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(4 !== 4, 'arguments/0'), {
   content: 'assert(4 !== 4)',

--- a/test/fixtures/BinaryExpression/expected.js
+++ b/test/fixtures/BinaryExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/CallExpression/expected-presets-es2015.js
+++ b/test/fixtures/CallExpression/expected-presets-es2015.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder(),
-    _rec9 = _powerAssertRecorder(),
-    _rec10 = _powerAssertRecorder(),
-    _rec11 = _powerAssertRecorder(),
-    _rec12 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder(),
+    _rec9 = new _powerAssertRecorder(),
+    _rec10 = new _powerAssertRecorder(),
+    _rec11 = new _powerAssertRecorder(),
+    _rec12 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(func(), 'arguments/0'), {
   content: 'assert(func())',

--- a/test/fixtures/CallExpression/expected-presets-es2015.js
+++ b/test/fixtures/CallExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/CallExpression/expected.js
+++ b/test/fixtures/CallExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/CallExpression/expected.js
+++ b/test/fixtures/CallExpression/expected.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder(),
-    _rec9 = _powerAssertRecorder(),
-    _rec10 = _powerAssertRecorder(),
-    _rec11 = _powerAssertRecorder(),
-    _rec12 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder(),
+    _rec9 = new _powerAssertRecorder(),
+    _rec10 = new _powerAssertRecorder(),
+    _rec11 = new _powerAssertRecorder(),
+    _rec12 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(func(), 'arguments/0'), {
   content: 'assert(func())',

--- a/test/fixtures/ConditionalExpression/expected-presets-es2015.js
+++ b/test/fixtures/ConditionalExpression/expected-presets-es2015.js
@@ -2,12 +2,12 @@
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(foo, 'arguments/0/test') ? _rec._capt(bar, 'arguments/0/consequent') : _rec._capt(baz, 'arguments/0/alternate'), {
   content: 'assert(foo ? bar : baz)',

--- a/test/fixtures/ConditionalExpression/expected-presets-es2015.js
+++ b/test/fixtures/ConditionalExpression/expected-presets-es2015.js
@@ -2,7 +2,7 @@
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/ConditionalExpression/expected.js
+++ b/test/fixtures/ConditionalExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/ConditionalExpression/expected.js
+++ b/test/fixtures/ConditionalExpression/expected.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(foo, 'arguments/0/test') ? _rec._capt(bar, 'arguments/0/consequent') : _rec._capt(baz, 'arguments/0/alternate'), {
   content: 'assert(foo ? bar : baz)',

--- a/test/fixtures/FunctionExpression/expected-presets-es2015.js
+++ b/test/fixtures/FunctionExpression/expected-presets-es2015.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder();
 
 assert(function (a, b) {
   return a + b;

--- a/test/fixtures/FunctionExpression/expected-presets-es2015.js
+++ b/test/fixtures/FunctionExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder();
 
 assert(function (a, b) {

--- a/test/fixtures/FunctionExpression/expected.js
+++ b/test/fixtures/FunctionExpression/expected.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder();
 
 assert(function (a, b) {
   return a + b;

--- a/test/fixtures/FunctionExpression/expected.js
+++ b/test/fixtures/FunctionExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder();
 
 assert(function (a, b) {

--- a/test/fixtures/Identifier/expected-presets-es2015.js
+++ b/test/fixtures/Identifier/expected-presets-es2015.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder(),
-    _rec9 = _powerAssertRecorder(),
-    _rec10 = _powerAssertRecorder(),
-    _rec11 = _powerAssertRecorder(),
-    _rec12 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder(),
+    _rec9 = new _powerAssertRecorder(),
+    _rec10 = new _powerAssertRecorder(),
+    _rec11 = new _powerAssertRecorder(),
+    _rec12 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(falsyStr, 'arguments/0'), {
   content: 'assert(falsyStr)',

--- a/test/fixtures/Identifier/expected-presets-es2015.js
+++ b/test/fixtures/Identifier/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/Identifier/expected.js
+++ b/test/fixtures/Identifier/expected.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder(),
-    _rec9 = _powerAssertRecorder(),
-    _rec10 = _powerAssertRecorder(),
-    _rec11 = _powerAssertRecorder(),
-    _rec12 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder(),
+    _rec9 = new _powerAssertRecorder(),
+    _rec10 = new _powerAssertRecorder(),
+    _rec11 = new _powerAssertRecorder(),
+    _rec12 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(falsyStr, 'arguments/0'), {
   content: 'assert(falsyStr)',

--- a/test/fixtures/Identifier/expected.js
+++ b/test/fixtures/Identifier/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/Literal/expected-presets-es2015.js
+++ b/test/fixtures/Literal/expected-presets-es2015.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder();
 
 assert(false);
 

--- a/test/fixtures/Literal/expected-presets-es2015.js
+++ b/test/fixtures/Literal/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/Literal/expected.js
+++ b/test/fixtures/Literal/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/Literal/expected.js
+++ b/test/fixtures/Literal/expected.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder();
 
 assert(false);
 

--- a/test/fixtures/LogicalExpression/expected-presets-es2015.js
+++ b/test/fixtures/LogicalExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/LogicalExpression/expected-presets-es2015.js
+++ b/test/fixtures/LogicalExpression/expected-presets-es2015.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(_rec._capt(5 < _rec._capt(actual, 'arguments/0/left/right'), 'arguments/0/left') && _rec._capt(_rec._capt(actual, 'arguments/0/right/left') < 13, 'arguments/0/right'), 'arguments/0'), {
   content: 'assert(5 < actual && actual < 13)',

--- a/test/fixtures/LogicalExpression/expected.js
+++ b/test/fixtures/LogicalExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/LogicalExpression/expected.js
+++ b/test/fixtures/LogicalExpression/expected.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(_rec._capt(5 < _rec._capt(actual, 'arguments/0/left/right'), 'arguments/0/left') && _rec._capt(_rec._capt(actual, 'arguments/0/right/left') < 13, 'arguments/0/right'), 'arguments/0'), {
   content: 'assert(5 < actual && actual < 13)',

--- a/test/fixtures/MemberExpression/expected-presets-es2015.js
+++ b/test/fixtures/MemberExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/MemberExpression/expected-presets-es2015.js
+++ b/test/fixtures/MemberExpression/expected-presets-es2015.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder(),
-    _rec9 = _powerAssertRecorder(),
-    _rec10 = _powerAssertRecorder(),
-    _rec11 = _powerAssertRecorder(),
-    _rec12 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder(),
+    _rec9 = new _powerAssertRecorder(),
+    _rec10 = new _powerAssertRecorder(),
+    _rec11 = new _powerAssertRecorder(),
+    _rec12 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(_rec._capt(foo, 'arguments/0/object').bar, 'arguments/0'), {
   content: 'assert(foo.bar)',

--- a/test/fixtures/MemberExpression/expected.js
+++ b/test/fixtures/MemberExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/MemberExpression/expected.js
+++ b/test/fixtures/MemberExpression/expected.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder(),
-    _rec9 = _powerAssertRecorder(),
-    _rec10 = _powerAssertRecorder(),
-    _rec11 = _powerAssertRecorder(),
-    _rec12 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder(),
+    _rec9 = new _powerAssertRecorder(),
+    _rec10 = new _powerAssertRecorder(),
+    _rec11 = new _powerAssertRecorder(),
+    _rec12 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(_rec._capt(foo, 'arguments/0/object').bar, 'arguments/0'), {
   content: 'assert(foo.bar)',

--- a/test/fixtures/Mocha/expected-presets-es2015.js
+++ b/test/fixtures/Mocha/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; };
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
 
 var assert = require('power-assert');
 
@@ -9,7 +9,7 @@ describe('Array#indexOf()', function () {
         this.ary = [1, 2, 3];
     });
     it('should return index when the value is present', function () {
-        var _rec = _powerAssertRecorder();
+        var _rec = new _powerAssertRecorder();
 
         var who = 'ariya',
             two = 2;
@@ -20,7 +20,7 @@ describe('Array#indexOf()', function () {
         }));
     });
     it('should return -1 when the value is not present', function () {
-        var _rec2 = _powerAssertRecorder();
+        var _rec2 = new _powerAssertRecorder();
 
         var minusOne = -1,
             two = 2;

--- a/test/fixtures/Mocha/expected-presets-es2015.js
+++ b/test/fixtures/Mocha/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }();
 
 var assert = require('power-assert');
 

--- a/test/fixtures/Mocha/expected.js
+++ b/test/fixtures/Mocha/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }();
 
 var assert = require('power-assert');
 

--- a/test/fixtures/Mocha/expected.js
+++ b/test/fixtures/Mocha/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; };
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
 
 var assert = require('power-assert');
 
@@ -9,7 +9,7 @@ describe('Array#indexOf()', function () {
         this.ary = [1, 2, 3];
     });
     it('should return index when the value is present', function () {
-        var _rec = _powerAssertRecorder();
+        var _rec = new _powerAssertRecorder();
 
         var who = 'ariya',
             two = 2;
@@ -20,7 +20,7 @@ describe('Array#indexOf()', function () {
         }));
     });
     it('should return -1 when the value is not present', function () {
-        var _rec2 = _powerAssertRecorder();
+        var _rec2 = new _powerAssertRecorder();
 
         var minusOne = -1,
             two = 2;

--- a/test/fixtures/NewExpression/expected-presets-es2015.js
+++ b/test/fixtures/NewExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/NewExpression/expected-presets-es2015.js
+++ b/test/fixtures/NewExpression/expected-presets-es2015.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(new Date(), 'arguments/0'), {
   content: 'assert(new Date())',

--- a/test/fixtures/NewExpression/expected.js
+++ b/test/fixtures/NewExpression/expected.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(new Date(), 'arguments/0'), {
   content: 'assert(new Date())',

--- a/test/fixtures/NewExpression/expected.js
+++ b/test/fixtures/NewExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/ObjectExpression/expected-presets-es2015.js
+++ b/test/fixtures/ObjectExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/ObjectExpression/expected-presets-es2015.js
+++ b/test/fixtures/ObjectExpression/expected-presets-es2015.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt({ foo: _rec._capt(bar, 'arguments/0/properties/0/value'), hoge: _rec._capt(fuga, 'arguments/0/properties/1/value') }, 'arguments/0'), {
   content: 'assert({ foo: bar, hoge: fuga })',

--- a/test/fixtures/ObjectExpression/expected.js
+++ b/test/fixtures/ObjectExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/ObjectExpression/expected.js
+++ b/test/fixtures/ObjectExpression/expected.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt({ foo: _rec._capt(bar, 'arguments/0/properties/0/value'), hoge: _rec._capt(fuga, 'arguments/0/properties/1/value') }, 'arguments/0'), {
   content: 'assert({ foo: bar, hoge: fuga })',

--- a/test/fixtures/Property/expected-presets-es2015.js
+++ b/test/fixtures/Property/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/Property/expected-presets-es2015.js
+++ b/test/fixtures/Property/expected-presets-es2015.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder();
 
 function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 

--- a/test/fixtures/Property/expected.js
+++ b/test/fixtures/Property/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/Property/expected.js
+++ b/test/fixtures/Property/expected.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt({ [_rec._capt(num, 'arguments/0/properties/0/key')]: _rec._capt(foo, 'arguments/0/properties/0/value') }, 'arguments/0'), {
   content: 'assert({ [num]: foo })',

--- a/test/fixtures/SpreadElement/expected-presets-es2015.js
+++ b/test/fixtures/SpreadElement/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder();

--- a/test/fixtures/SpreadElement/expected-presets-es2015.js
+++ b/test/fixtures/SpreadElement/expected-presets-es2015.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder();
 
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 

--- a/test/fixtures/SpreadElement/expected.js
+++ b/test/fixtures/SpreadElement/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder();

--- a/test/fixtures/SpreadElement/expected.js
+++ b/test/fixtures/SpreadElement/expected.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(hello(..._rec._capt(names, 'arguments/0/arguments/0/argument')), 'arguments/0'), {
   content: 'assert(hello(...names))',

--- a/test/fixtures/TaggedTemplateExpression/expected-presets-es2015.js
+++ b/test/fixtures/TaggedTemplateExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder();

--- a/test/fixtures/TaggedTemplateExpression/expected-presets-es2015.js
+++ b/test/fixtures/TaggedTemplateExpression/expected-presets-es2015.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder();
 
 var _templateObject = _taggedTemplateLiteral(['a', ''], ['a', '']),
     _templateObject2 = _taggedTemplateLiteral(['a', 'b', 'c', ''], ['a', 'b', 'c', '']),

--- a/test/fixtures/TaggedTemplateExpression/expected.js
+++ b/test/fixtures/TaggedTemplateExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder();

--- a/test/fixtures/TaggedTemplateExpression/expected.js
+++ b/test/fixtures/TaggedTemplateExpression/expected.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(fn`a${ 1 }`, 'arguments/0'), {
   content: 'assert(fn`a${ 1 }`)',

--- a/test/fixtures/TemplateLiteral/expected-presets-es2015.js
+++ b/test/fixtures/TemplateLiteral/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder();

--- a/test/fixtures/TemplateLiteral/expected-presets-es2015.js
+++ b/test/fixtures/TemplateLiteral/expected-presets-es2015.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt('Hello', 'arguments/0'), {
   content: 'assert(`Hello`)',

--- a/test/fixtures/TemplateLiteral/expected.js
+++ b/test/fixtures/TemplateLiteral/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder();

--- a/test/fixtures/TemplateLiteral/expected.js
+++ b/test/fixtures/TemplateLiteral/expected.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(`Hello`, 'arguments/0'), {
   content: 'assert(`Hello`)',

--- a/test/fixtures/UnaryExpression/expected-presets-es2015.js
+++ b/test/fixtures/UnaryExpression/expected-presets-es2015.js
@@ -2,7 +2,7 @@
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/UnaryExpression/expected-presets-es2015.js
+++ b/test/fixtures/UnaryExpression/expected-presets-es2015.js
@@ -2,15 +2,15 @@
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(!_rec._capt(truth, 'arguments/0/argument'), 'arguments/0'), {
   content: 'assert(!truth)',

--- a/test/fixtures/UnaryExpression/expected.js
+++ b/test/fixtures/UnaryExpression/expected.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(!_rec._capt(truth, 'arguments/0/argument'), 'arguments/0'), {
   content: 'assert(!truth)',

--- a/test/fixtures/UnaryExpression/expected.js
+++ b/test/fixtures/UnaryExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/UpdateExpression/expected-presets-es2015.js
+++ b/test/fixtures/UpdateExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/UpdateExpression/expected-presets-es2015.js
+++ b/test/fixtures/UpdateExpression/expected-presets-es2015.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(++foo, 'arguments/0'), {
   content: 'assert(++foo)',

--- a/test/fixtures/UpdateExpression/expected.js
+++ b/test/fixtures/UpdateExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/UpdateExpression/expected.js
+++ b/test/fixtures/UpdateExpression/expected.js
@@ -1,10 +1,10 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder();
 
 assert(_rec._expr(_rec._capt(++foo, 'arguments/0'), {
   content: 'assert(++foo)',

--- a/test/fixtures/YieldExpression/expected-presets-es2015.js
+++ b/test/fixtures/YieldExpression/expected-presets-es2015.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }();
 
 var _marked = [gen].map(regeneratorRuntime.mark);
 

--- a/test/fixtures/YieldExpression/expected-presets-es2015.js
+++ b/test/fixtures/YieldExpression/expected-presets-es2015.js
@@ -1,11 +1,11 @@
 'use strict';
 
-var _powerAssertRecorder = function _powerAssertRecorder() { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; };
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
 
 var _marked = [gen].map(regeneratorRuntime.mark);
 
 function gen(a) {
-  var _rec = _powerAssertRecorder();
+  var _rec = new _powerAssertRecorder();
 
   return regeneratorRuntime.wrap(function gen$(_context) {
     while (1) {

--- a/test/fixtures/YieldExpression/expected.js
+++ b/test/fixtures/YieldExpression/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }();
 
 function* gen(a) {
   var _rec = new _powerAssertRecorder();

--- a/test/fixtures/YieldExpression/expected.js
+++ b/test/fixtures/YieldExpression/expected.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; };
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
 
 function* gen(a) {
-  var _rec = _powerAssertRecorder();
+  var _rec = new _powerAssertRecorder();
 
   assert(_rec._expr(_rec._capt(_rec._capt((yield a), 'arguments/0/left') === 3, 'arguments/0'), {
     content: 'assert((yield a) === 3)',

--- a/test/fixtures/customPatterns/expected.js
+++ b/test/fixtures/customPatterns/expected.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }(),
     _rec = new _powerAssertRecorder(),
     _rec2 = new _powerAssertRecorder(),
     _rec3 = new _powerAssertRecorder(),

--- a/test/fixtures/customPatterns/expected.js
+++ b/test/fixtures/customPatterns/expected.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; },
-    _rec = _powerAssertRecorder(),
-    _rec2 = _powerAssertRecorder(),
-    _rec3 = _powerAssertRecorder(),
-    _rec4 = _powerAssertRecorder(),
-    _rec5 = _powerAssertRecorder(),
-    _rec6 = _powerAssertRecorder(),
-    _rec7 = _powerAssertRecorder(),
-    _rec8 = _powerAssertRecorder(),
-    _rec9 = _powerAssertRecorder(),
-    _rec10 = _powerAssertRecorder(),
-    _rec11 = _powerAssertRecorder(),
-    _rec12 = _powerAssertRecorder();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }(),
+    _rec = new _powerAssertRecorder(),
+    _rec2 = new _powerAssertRecorder(),
+    _rec3 = new _powerAssertRecorder(),
+    _rec4 = new _powerAssertRecorder(),
+    _rec5 = new _powerAssertRecorder(),
+    _rec6 = new _powerAssertRecorder(),
+    _rec7 = new _powerAssertRecorder(),
+    _rec8 = new _powerAssertRecorder(),
+    _rec9 = new _powerAssertRecorder(),
+    _rec10 = new _powerAssertRecorder(),
+    _rec11 = new _powerAssertRecorder(),
+    _rec12 = new _powerAssertRecorder();
 
 assert.isNull(_rec._expr(_rec._capt(falsy, 'arguments/0'), {
   content: 'assert.isNull(falsy)',

--- a/test/fixtures/inputSourceMap/expected.js
+++ b/test/fixtures/inputSourceMap/expected.js
@@ -1,4 +1,4 @@
-var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, source) { return { powerAssertContext: { value: value, events: this.captured }, source: source }; }; return PowerAssertRecorder; }();
 
 var Person, assert;
 

--- a/test/fixtures/inputSourceMap/expected.js
+++ b/test/fixtures/inputSourceMap/expected.js
@@ -1,4 +1,4 @@
-var _powerAssertRecorder = function () { var captured = []; function _capt(value, espath) { captured.push({ value: value, espath: espath }); return value; } function _expr(value, args) { var source = { content: args.content, filepath: args.filepath, line: args.line }; if (args.generator) { source.generator = true; } if (args.async) { source.async = true; } return { powerAssertContext: { value: value, events: captured }, source: source }; } return { _capt: _capt, _expr: _expr }; };
+var _powerAssertRecorder = function () { function PowerAssertRecorder() { this.captured = []; } PowerAssertRecorder.prototype._capt = function _capt(value, espath) { this.captured.push({ value: value, espath: espath }); return value; }; PowerAssertRecorder.prototype._expr = function _expr(value, args) { return { powerAssertContext: { value: value, events: this.captured }, source: { content: args.content, filepath: args.filepath, line: args.line, generator: !!args.generator, async: !!args.async } }; }; return PowerAssertRecorder; }();
 
 var Person, assert;
 
@@ -20,7 +20,7 @@ describe("various types", function () {
     }, NaN, Infinity, /^not/, new Person("alice", 3)];
   });
   return it("demo", function () {
-    var _rec = _powerAssertRecorder();
+    var _rec = new _powerAssertRecorder();
 
     var bob, index;
     index = this.types.length - 1;


### PR DESCRIPTION
The current method of creating a PowerAssertRecorder prevents some optimizations by the V8 compiler.

Specifically, it creates many extra closure contexts, and prevents the use of [hidden classes](http://debuggable.com/posts/understanding-hidden-classes-in-v8:4c7e81e4-1330-4398-8bd2-761bcbdd56cb).

My test suite was seeing roughly a 5% boost.