### PR TITLE
feat: change `embedAst` option's default to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ Configuration options for `babel-plugin-espower`. If not passed, default options
         'assert.deepStrictEqual(actual, expected, [message])',
         'assert.notDeepStrictEqual(actual, expected, [message])'
     ],
-    embedAst: false,
+    embedAst: true,
     visitorKeys: babel.types.VISITOR_KEYS,
     astWhiteList: babel.types.BUILDER_KEYS,
     sourceRoot: process.cwd(),

--- a/lib/default-options.js
+++ b/lib/default-options.js
@@ -2,7 +2,7 @@
 
 module.exports = function defaultOptions () {
     return {
-        embedAst: false,
+        embedAst: true,
         patterns: [
             'assert(value, [message])',
             'assert.ok(value, [message])',

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,11 @@ function testTransform (fixtureName, extraOptions) {
         var expectedFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'expected.js');
         var actualFilepath = path.resolve(__dirname, 'fixtures', fixtureName, 'actual.js');
         var result = babel.transformFileSync(fixtureFilepath, assign({
-            plugins: [createEspowerPlugin(babel)]
+            plugins: [
+                createEspowerPlugin(babel, {
+                    embedAst: false
+                })
+            ]
         }, extraOptions));
         var actual = result.code + '\n';
         var expected = fs.readFileSync(expectedFilepath, 'utf8');
@@ -50,6 +54,7 @@ describe('babel-plugin-espower', function () {
     testTransform('inputSourceMap', {
         plugins: [
             createEspowerPlugin(babel, {
+                embedAst: false,
                 sourceRoot: "/absolute/"
             })
         ]
@@ -57,6 +62,7 @@ describe('babel-plugin-espower', function () {
     testTransform('customPatterns', {
         plugins: [
             createEspowerPlugin(babel, {
+                embedAst: false,
                 patterns: [
                     'assert.isNull(object, [message])',
                     'assert.same(actual, expected, [message])',


### PR DESCRIPTION
since most of babel users use experimental (non-ES-standard) syntax.

NOTICE:

This commit does not break builds but may slow your build time down.
If you are aware that you are not using non-ES-standard syntax, 
changing `embedAst` option to `false` restores the former behavior.