### PR TITLE
internal & interim module for preset to enable `embedAst` option by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "LICENSE",
     "index.js",
     "create.js",
+    "with-experimental-syntax.js",
     "lib",
     "package.json"
   ],

--- a/test/fixtures-with-presets-test.js
+++ b/test/fixtures-with-presets-test.js
@@ -3,7 +3,7 @@ var fs = require('fs');
 var path = require('path');
 var babel = require('babel-core');
 var assign = require('core-js/library/fn/object/assign');
-var createEspowerPlugin = require('../create');
+var espowerPluginWithExperimentalSyntaxSupport = require('../with-experimental-syntax');
 
 function testTransform (fixtureName, extraSuffix, extraOptions) {
     it(fixtureName, function () {
@@ -18,9 +18,7 @@ function testTransform (fixtureName, extraSuffix, extraOptions) {
                 'react'
             ],
             plugins: [
-                createEspowerPlugin(babel, {
-                    embedAst: true
-                })
+                espowerPluginWithExperimentalSyntaxSupport
             ]
         }, extraOptions));
         var actual = result.code + '\n';

--- a/with-experimental-syntax.js
+++ b/with-experimental-syntax.js
@@ -1,0 +1,13 @@
+/**
+ * Bridge module for babel-preset-power-assert to enable `embedAst` option by default.
+ * 
+ * NOTE: this is an internal & interim module and will be removed from next major version,
+ *   since `embedAst` will be true by default in next major.
+ */
+'use strict';
+
+var createEspowerPlugin = require('./create');
+
+module.exports = function (babel) {
+    return createEspowerPlugin(babel, { embedAst: true });
+};


### PR DESCRIPTION
NOTE: this is an internal & interim module and will be removed from next major version, since `embedAst` will be true by default in next major.